### PR TITLE
Swiftoberfest info page changes

### DIFF
--- a/app/content/css/challenges.scss
+++ b/app/content/css/challenges.scss
@@ -1256,7 +1256,7 @@
       &.leaderboard-table {
         @media only screen and (min-width: 992px) {
           position: absolute;
-          top: 32px;
+          top: -100px;
           left: 0;
         }
       }
@@ -1279,8 +1279,8 @@
         &:before {
           background: url('../images/svg/SYS-IOS-Swift-Ready-06.svg');
           background-repeat: no-repeat;
-          background-size: 325px auto;
-          background-position: 35px 0;
+          background-size: 220px auto;
+          background-position: 65px 0;
           @media only screen and (max-width: 991px) {
             width: 494px;
             height: 524px;

--- a/app/swiftoberfest/info.coffee
+++ b/app/swiftoberfest/info.coffee
@@ -4,7 +4,7 @@ swiftoberfestInfo = ($scope, $stateParams, FaqService, LeaderboardService) ->
   vm = this
   vm.shown = []
   vm.questions = FaqService.getQuestions()
-  vm.leaderboardMonth = 'october'
+  vm.leaderboardMonth = 'overall'
   vm.loadingLeaderboard = true
 
   getScores = () ->

--- a/app/swiftoberfest/info.jade
+++ b/app/swiftoberfest/info.jade
@@ -77,18 +77,18 @@
     .row.leaderboard-container
       .col-xs-12.col-md-6.content-col.no-image.leaderboard-table(ng-hide="vm.loadingLeaderboard")
         .row.section-header
+          .col-xs-6.col-md-3.leaderboard-months(ng-class="{'active': vm.isLeaderboardMonth('overall')}",ng-click="vm.changeLeaderboardMonth('overall')") Overall
           .col-xs-6.col-md-3.leaderboard-months(ng-class="{'active': vm.isLeaderboardMonth('october')}",ng-click="vm.changeLeaderboardMonth('october')") October
           .col-xs-6.col-md-3.leaderboard-months(ng-class="{'active': vm.isLeaderboardMonth('november')}",ng-click="vm.changeLeaderboardMonth('november')") November
           .col-xs-6.col-md-3.leaderboard-months(ng-class="{'active': vm.isLeaderboardMonth('december')}",ng-click="vm.changeLeaderboardMonth('december')") December
-          .col-xs-6.col-md-3.leaderboard-months(ng-class="{'active': vm.isLeaderboardMonth('overall')}",ng-click="vm.changeLeaderboardMonth('overall')") Overall
 
         table.table
           tr
             th Handle
-            th Score
-          tr(ng-repeat="entry in vm.scores | limitTo:6 | orderBy:'score':true")
+            th.text-center Score
+          tr(ng-repeat="entry in vm.scores | limitTo:10 | orderBy:'score':true")
             td {{entry.handle}}
-            td {{entry.score}}
+            td.text-center {{entry.score}}
           tr(ng-show="vm.scores.length === 0")
             td(colspan="2") No scores available
 


### PR DESCRIPTION
1. Set 'overall' to be the default scoring type
2. Move overall type to the left so its the first in the series
3. Allow up to 10 instead of the earlier 6 rankings
4. Center justify the score in the table